### PR TITLE
Fix magic link authentication endpoint routing

### DIFF
--- a/auth-module.js
+++ b/auth-module.js
@@ -217,7 +217,12 @@ class KartelAuth {
         console.log(`🔐 Attempting login for: ${email} (method: ${password ? 'password' : 'magic link'})`);
         
         try {
-            const response = await fetch('/.netlify/functions/member-login', {
+            // Use different endpoints based on authentication method
+            const endpoint = password ? 
+                '/.netlify/functions/member-login' : 
+                '/.netlify/functions/request-login-link';
+            
+            const response = await fetch(endpoint, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ email, password })


### PR DESCRIPTION
## Summary
- Fixed magic link authentication by correcting endpoint routing in the login function
- Magic link requests now properly call `request-login-link` instead of `member-login`
- Resolves 401 unauthorized errors when users request magic links

## Changes Made
- Updated `auth-module.js` login function to use correct endpoints based on authentication method
- Password authentication continues to use `member-login` endpoint
- Magic link requests now use `request-login-link` endpoint

## Test Plan
- [x] All existing tests pass
- [x] Code committed and ready for testing
- [ ] Test magic link request functionality on deployed version
- [ ] Verify password authentication still works correctly
- [ ] Test complete magic link flow (request → email → login)

🤖 Generated with [Claude Code](https://claude.ai/code)