### PR TITLE
Fix: Remove auth requirement from public content functions

### DIFF
--- a/netlify/functions/get-experience-video.js
+++ b/netlify/functions/get-experience-video.js
@@ -6,11 +6,6 @@ exports.handler = async (event, context) => {
     }
 
     try {
-        const authHeader = event.headers.authorization;
-        if (!authHeader || !authHeader.startsWith('Bearer ')) {
-            return { statusCode: 401, body: JSON.stringify({ error: 'Unauthorized' }) };
-        }
-
         // Check environment variables
         if (!process.env.NETLIFY_SITE_ID || !process.env.NETLIFY_ACCESS_TOKEN) {
             return {

--- a/netlify/functions/get-faqs.js
+++ b/netlify/functions/get-faqs.js
@@ -6,11 +6,6 @@ exports.handler = async (event, context) => {
     }
 
     try {
-        const authHeader = event.headers.authorization;
-        if (!authHeader || !authHeader.startsWith('Bearer ')) {
-            return { statusCode: 401, body: JSON.stringify({ error: 'Unauthorized' }) };
-        }
-
         // Check environment variables
         if (!process.env.NETLIFY_SITE_ID || !process.env.NETLIFY_ACCESS_TOKEN) {
             return {

--- a/netlify/functions/get-gallery.js
+++ b/netlify/functions/get-gallery.js
@@ -6,11 +6,6 @@ exports.handler = async (event, context) => {
     }
 
     try {
-        const authHeader = event.headers.authorization;
-        if (!authHeader || !authHeader.startsWith('Bearer ')) {
-            return { statusCode: 401, body: JSON.stringify({ error: 'Unauthorized' }) };
-        }
-
         // Check environment variables
         if (!process.env.NETLIFY_SITE_ID || !process.env.NETLIFY_ACCESS_TOKEN) {
             return {


### PR DESCRIPTION
## Summary
- Remove Bearer token authentication from `get-gallery.js`, `get-faqs.js`, and `get-experience-video.js`
- Fix 401 Unauthorized errors when loading index.html public content
- These endpoints provide public content and should be accessible without authentication

## Test plan
- [x] Verify index.html loads without 401 errors in console
- [x] Test gallery, FAQ, and video content loads properly
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)